### PR TITLE
Change Menue name from "Versions" to "Releases"

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -92,7 +92,7 @@ const config: Config = {
         },
         {
           type: 'dropdown',
-          label: 'Versions',
+          label: 'Releases',
           position: 'left',
           items: [
             {


### PR DESCRIPTION
In the mobile view the drop down of the "versions" get put on the sidebar as a "chapter". To avoid having 2 menu items with the same name we renamed it.
![image](https://github.com/catenax-eV/catenax-ev.github.io/assets/82021442/29f39dcc-56df-4fb8-83e9-f4b9adee2604)
