### PR TITLE
Country Clearance: Allow List and Conditional List

### DIFF
--- a/docs/regulatory-framework/30000ft/country-clearance-list.md
+++ b/docs/regulatory-framework/30000ft/country-clearance-list.md
@@ -5,7 +5,7 @@ pagination_next: null
 
 # Country Clearance List
 
-## Clearance List "White List"
+## Clearance List "Allow List"
 
 > *Onboarding possible without limitations*
 
@@ -53,7 +53,7 @@ pagination_next: null
 | United States of America | US |
 | Vietnam | VN |
 
-## Clearance List "Yellow List"
+## Clearance List "Conditional List"
 
 > *Onboarding possible after due diligence check, followed by seperate approval by the Catena-X association*
 


### PR DESCRIPTION
Altered the naming of the two country clearance lists to a more descriptive naming and changed "White List" --> "Allow List" as well as "Yellow List" --> "Conditional List". As a side effect, the naming is also more inclusive for the international audience Catena-X is operating in.