### PR TITLE
chore(vesrioning): rename current version label

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -43,6 +43,9 @@ const config: Config = {
             current: {
               label: 'Jupiter (preview)',
             },
+            '24.03': {
+              label: '24.03 (current)',
+            },
           },
         },
         theme: {


### PR DESCRIPTION
## Description

This PR changes the label of the current version to

<img width="178" alt="image" src="https://github.com/user-attachments/assets/e8de04d0-c932-4d93-89f7-ded329bafd5d">
