### PR TITLE
chore(landing-page): adapt landing page

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -82,12 +82,6 @@ const config: Config = {
       items: [
         {
           type: "docSidebar",
-          sidebarId: "sidebar_working_model",
-          position: "left",
-          label: "Working Model",
-        },
-        {
-          type: "docSidebar",
           sidebarId: "sidebar_standards",
           position: "left",
           label: "Standards",

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -11,16 +11,6 @@ type FeatureItem = {
 
 const FeatureList: FeatureItem[] = [
   {
-    title: 'Working Model',
-    Svg: require('@site/static/img/working-model-icon.svg').default,
-    path: '/docs/working-model/overview',
-    description: (
-      <>
-          Here you will find all the information about the <a href="/docs/working-model/overview">Working Model</a>.
-      </>
-    ),
-  },
-  {
     title: 'Standards',
     Svg: require('@site/static/img/standards-icon.svg').default,
     path: '/docs/standards/overview',
@@ -47,6 +37,16 @@ const FeatureList: FeatureItem[] = [
     description: (
       <>
           Here you will find all the information about the <a href="/docs/operating-model/why-introduction">Operating Model</a>.
+      </>
+    ),
+  },
+  {
+    title: 'Working Model',
+    Svg: require('@site/static/img/working-model-icon.svg').default,
+    path: '/docs/working-model/overview',
+    description: (
+      <>
+          Here you will find all the information about the <a href="/docs/working-model/overview">Working Model</a>.
       </>
     ),
   },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -79,7 +79,3 @@
 .separator-bottom{
   border-bottom: 1px solid #CCC;
 }
-
-.col--4 { 
-  --ifm-col-width: 25%;
-}


### PR DESCRIPTION
This PR adapts the landing page

- delete Working Model from Nav Bar
- reorder icons
- Working model in second line

<img width="1906" alt="image" src="https://github.com/user-attachments/assets/c7787b16-7eeb-4e91-b20f-a318961e18c1">
