### PR TITLE
Fix .md-formatting

### DIFF
--- a/docs/standards/CX-0002-DigitalTwinsInCatenaX/CX-0002-DigitalTwinsInCatenaX.md
+++ b/docs/standards/CX-0002-DigitalTwinsInCatenaX/CX-0002-DigitalTwinsInCatenaX.md
@@ -406,14 +406,14 @@ The following deviations are defined:
 
 EXAMPLE for Self-Description (**GetSelfDescription**) of a Digital Twin Registry solution :
 
-````json
+```json
 {
   "profiles": [
     "https://admin-shell.io/aas/API/3/0/DiscoveryServiceSpecification/SSP-001",
     "https://admin-shell.io/aas/API/3/0/AssetAdministrationShellRegistryServiceSpecification/SSP-002"
    ]
 }
-````
+```
 
 API paths SHOULD be versioned only holding the major version of the AAS specification, for instance `/v3/`.
 

--- a/docs/standards/CX-0123-QualityUseCaseStandard/CX-0123-QualityUseCaseStandard.md
+++ b/docs/standards/CX-0123-QualityUseCaseStandard/CX-0123-QualityUseCaseStandard.md
@@ -277,7 +277,7 @@ This semantic model "Qualtiy Task" has the unique identifier
 
 ```text
 <urn:samm:io.catenax.quality_task:2.0.0#>
-````
+```
 
 #### 3.1.5 FORMATS OF SEMANTIC MODEL
 

--- a/docs/standards/CX-0125-TraceabilityUseCase/CX-0125-TraceabilityUseCase.md
+++ b/docs/standards/CX-0125-TraceabilityUseCase/CX-0125-TraceabilityUseCase.md
@@ -521,8 +521,6 @@ Example JSON Payload: Submodel "SpecialCharacteristicMeasurement" for a qualitat
 }
 ```
 
-````
-
 ## 4 APPLICATION PROGRAMMING INTERFACES
 
 > *This section is normative*
@@ -598,7 +596,7 @@ When using the Tractus-X EDC, the following asset **MUST** be registered. Other 
     ...
   }
 }  
-````
+```
 
 The variable \{\{httpServerWhichOffersTheHttpEndpoint\}\} **MUST** be set to the HTTP server that offers the endpoint. The path /qualityinvestigations/receive **MAY** align with the HTTP POST path as stated in Section 4.1.2.1. In that sense it can change dependent on the traceability application.
 

--- a/versioned_docs/version-24.03/standards/CX-0002-DigitalTwinsInCatenaX/CX-0002-DigitalTwinsinCatenaX.md
+++ b/versioned_docs/version-24.03/standards/CX-0002-DigitalTwinsInCatenaX/CX-0002-DigitalTwinsinCatenaX.md
@@ -318,14 +318,14 @@ The following deviations are defined:
 
 EXAMPLE for Self-Description (**GetSelfDescription**) of a Digital Twin Registry solution :
 
-````json
+```json
 {
   "profiles": [
     "https://admin-shell.io/aas/API/3/0/DiscoveryServiceSpecification/SSP-001",
     "https://admin-shell.io/aas/API/3/0/AssetAdministrationShellRegistryServiceSpecification/SSP-002"
    ]
 }
-````
+```
 
 #### 2.1.3 Available Data Types
 

--- a/versioned_docs/version-Io/standards/CX-0002-DigitalTwinsInCatenaX/CX-0002-DigitalTwinsInCatenaX.md
+++ b/versioned_docs/version-Io/standards/CX-0002-DigitalTwinsInCatenaX/CX-0002-DigitalTwinsInCatenaX.md
@@ -406,14 +406,14 @@ The following deviations are defined:
 
 EXAMPLE for Self-Description (**GetSelfDescription**) of a Digital Twin Registry solution :
 
-````json
+```json
 {
   "profiles": [
     "https://admin-shell.io/aas/API/3/0/DiscoveryServiceSpecification/SSP-001",
     "https://admin-shell.io/aas/API/3/0/AssetAdministrationShellRegistryServiceSpecification/SSP-002"
    ]
 }
-````
+```
 
 API paths SHOULD be versioned only holding the major version of the AAS specification, for instance `/v3/`.
 

--- a/versioned_docs/version-Io/standards/CX-0123-QualityUseCaseStandard/CX-0123-QualityUseCaseStandard.md
+++ b/versioned_docs/version-Io/standards/CX-0123-QualityUseCaseStandard/CX-0123-QualityUseCaseStandard.md
@@ -277,7 +277,7 @@ This semantic model "Qualtiy Task" has the unique identifier
 
 ```text
 <urn:samm:io.catenax.quality_task:2.0.0#>
-````
+```
 
 #### 3.1.5 FORMATS OF SEMANTIC MODEL
 

--- a/versioned_docs/version-Io/standards/CX-0125-TraceabilityUseCase/CX-0125-TraceabilityUseCase.md
+++ b/versioned_docs/version-Io/standards/CX-0125-TraceabilityUseCase/CX-0125-TraceabilityUseCase.md
@@ -521,8 +521,6 @@ Example JSON Payload: Submodel "SpecialCharacteristicMeasurement" for a qualitat
 }
 ```
 
-````
-
 ## 4 APPLICATION PROGRAMMING INTERFACES
 
 > *This section is normative*
@@ -598,7 +596,7 @@ When using the Tractus-X EDC, the following asset **MUST** be registered. Other 
     ...
   }
 }  
-````
+```
 
 The variable \{\{httpServerWhichOffersTheHttpEndpoint\}\} **MUST** be set to the HTTP server that offers the endpoint. The path /qualityinvestigations/receive **MAY** align with the HTTP POST path as stated in Section 4.1.2.1. In that sense it can change dependent on the traceability application.
 

--- a/versioned_docs/version-Jupiter/standards/CX-0002-DigitalTwinsInCatenaX/CX-0002-DigitalTwinsInCatenaX.md
+++ b/versioned_docs/version-Jupiter/standards/CX-0002-DigitalTwinsInCatenaX/CX-0002-DigitalTwinsInCatenaX.md
@@ -407,14 +407,14 @@ The following deviations are defined:
 
 EXAMPLE for Self-Description (**GetSelfDescription**) of a Digital Twin Registry solution :
 
-````json
+```json
 {
   "profiles": [
     "https://admin-shell.io/aas/API/3/0/DiscoveryServiceSpecification/SSP-001",
     "https://admin-shell.io/aas/API/3/0/AssetAdministrationShellRegistryServiceSpecification/SSP-002"
    ]
 }
-````
+```
 
 API paths SHOULD be versioned only holding the major version of the AAS specification, for instance `/v3/`.
 

--- a/versioned_docs/version-Jupiter/standards/CX-0123-QualityUseCaseStandard/CX-0123-QualityUseCaseStandard.md
+++ b/versioned_docs/version-Jupiter/standards/CX-0123-QualityUseCaseStandard/CX-0123-QualityUseCaseStandard.md
@@ -277,7 +277,7 @@ This semantic model "Qualtiy Task" has the unique identifier
 
 ```text
 <urn:samm:io.catenax.quality_task:2.0.0#>
-````
+```
 
 #### 3.1.5 FORMATS OF SEMANTIC MODEL
 


### PR DESCRIPTION
This PR fixes an issue caused by the Backquote \`.

This is not a linting issue, but it causes some representational issues with docusaurus.