### PR TITLE
feat: add redirects for rulebooks overview pages

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -47,6 +47,18 @@ const config: Config = {
             to: '/blog-releasenotes',
             from: ['/release-notes'],
           },
+          {
+            to: '/docs/rulebooks/overview',
+            from: [
+              '/docs/non-functional',
+            ],
+          },
+          {
+            to: '/docs/next/rulebooks/overview',
+            from: [
+              '/docs/next/non-functional',
+            ],
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Description

This pull request updates the Docusaurus configuration to improve URL redirects for documentation pages. The main change is the addition of new redirect rules to ensure users navigating to outdated "non-functional" documentation URLs are automatically sent to the updated "rulebooks/overview" pages.

Redirect improvements:

* Added a redirect from `/docs/non-functional` to `/docs/rulebooks/overview` to ensure users find the updated documentation location.
* Added a redirect from `/docs/next/non-functional` to `/docs/next/rulebooks/overview` for the "next" version of the docs.

@jSchuetz88 , @stanfaldin , @ther3sa can you somehow check if this is already the solution? 