### PR TITLE
Incorrect information in the DPC role

### DIFF
--- a/docs/operating-model/who-roles-in-the-catena-x-ecosystem/who-roles-in-the-catena-x-ecosystem.md
+++ b/docs/operating-model/who-roles-in-the-catena-x-ecosystem/who-roles-in-the-catena-x-ecosystem.md
@@ -285,7 +285,7 @@ A DPC provides, consumes, and processes data to collaborate with other data spac
 
 - A DPC **MAY** use the services of a CSP-A (e.g., marketplace).
 - A DPC **MUST** integrate and use CSP-B services to access his identity (e.g., identity wallet) and enable data exchange.
-- A DPC **MUST** use the services of one of the OSPs to register and onboard itself to the data space (e.g., registration service). This can be delegated to a BAP or ESP
+- A DPC **MUST** use the services of one of the OSPs to register and onboard itself to the data space (e.g., registration service).
 - A DPC **MAY** use advisory services from a qualified AP.
 
 - A DPC **MAY** use certified enablement services from a commercial ESP (e.g., a SaaS solution). Alternatively, a DPC can certify and operate its own enablement services.


### PR DESCRIPTION
In der Rollenbeschreibung der DPC Rolle steht ein Satz, dass auch ein BAP oder ein ESP onboarden kann. Dies ist falsch und muss gelöscht werden. Ein ESP oder ein BAP kann kein DPC onboarden. Dies funktioniert nur über ein OSP.
> A DPC must use the services of one of the OSPs to register and onboard itself to the data space (e.g., registration service). This can be delegated to a BAP or ESP

DSOC Decision: 
 - A DPC can only be onboarded via an authorized OSP.
 - BAPs or ESPs may support participants operationally, but cannot perform onboarding on behalf of an OSP.
 - Historical reasons for this wording were discussed but not considered valid anymore.

> - Remove the incorrect statement from the role description.

PR im Om -> https://github.com/catenax-eV/cx-operating-model/pull/225