### PR TITLE
feat(standards-owner): update standard-owners.json with new teams and standards

### DIFF
--- a/static/standard-owners.json
+++ b/static/standard-owners.json
@@ -82,6 +82,14 @@
       "label": "Engineering",
       "url": "https://github.com/orgs/catenax-eV/teams/cx-ex-team-engineering"
     },
+    "cx-ex-team-sus-material-accounting": {
+      "label": "Material Accounting",
+      "url": "https://github.com/orgs/catenax-eV/teams/cx-ex-team-sus-material-accounting"
+    },
+    "cx-ex-team-ecu": {
+      "label": "ECU",
+      "url": "https://github.com/orgs/catenax-eV/teams/cx-ex-team-ecu"
+    },
     "circular-economy": {
       "label": "Circular Economy"
     },
@@ -90,266 +98,343 @@
     },
     "logistics": {
       "label": "Logistics"
+    },
+    "battery-passport": {
+      "label": "Battery Passport"
     }
   },
   "standards": {
     "0001": {
+      "label": "Participant Agent Registration",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-dataspace-connectivity"
     },
     "0002": {
+      "label": "Digital Twins in Catena-X",
       "committeeId": "cx-com-team-industry-core",
       "expertGroupId": "cx-ex-team-dtr"
     },
     "0003": {
+      "label": "SAMM Aspect Meta Model",
       "committeeId": "cx-com-team-tc4m",
       "expertGroupId": null
     },
     "0005": {
+      "label": "Item Relationship Service API",
       "committeeId": "cx-com-team-supply-chain-and-quality",
       "expertGroupId": "cx-ex-team-traceability"
     },
     "0006": {
+      "label": "Registration and Initial Onboarding",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-onboarding-offboarding"
     },
     "0007": {
+      "label": "Minimal Data Provider Service Offering",
       "committeeId": null,
       "expertGroupId": null
     },
     "0009": {
+      "label": "CX Registration API",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-onboarding-offboarding"
     },
     "0010": {
+      "label": "Business Partner Number",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-bpdm"
     },
     "0012": {
+      "label": "Business Partner Data Pool API",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-bpdm"
     },
-    "0014": {
-      "committeeId": "cx-com-team-network-service",
-      "expertGroupId": "cx-ex-team-ssi"
-    },
-    "0015": {
-      "committeeId": "cx-com-team-network-service",
-      "expertGroupId": "cx-ex-team-ssi"
-    },
     "0018": {
+      "label": "Dataspace Connectivity",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-dataspace-connectivity"
     },
     "0044": {
+      "label": "ECLASS",
       "committeeId": "cx-com-team-tc4m",
       "expertGroupId": null
     },
     "0045": {
+      "label": "Data Chain Template",
       "committeeId": "cx-com-team-industry-core",
       "expertGroupId": null
     },
     "0049": {
+      "label": "DID Document Schema",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-ssi"
     },
     "0050": {
+      "label": "CX-Specific Credentials",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-ssi"
     },
     "0053": {
+      "label": "Discovery Finder and BPN Discovery Service APIs",
       "committeeId": "cx-com-team-industry-core",
       "expertGroupId": "cx-ex-team-dtr"
     },
     "0054": {
+      "label": "Application Service Release",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": null,
       "expertGroupNote": "Portal (not covered)"
     },
     "0055": {
+      "label": "Data Processing Patterns for IT System Integration",
       "committeeId": null,
       "expertGroupId": null
     },
     "0059": {
+      "label": "Use Case Behavioral Twin Endurance Predictor",
       "committeeId": "cx-com-team-supply-chain-and-quality",
       "expertGroupId": "cx-ex-team-behavioral-twin"
     },
     "0067": {
+      "label": "Ontology Models to realize federated query in Catena-X",
       "committeeId": "cx-com-team-tc4m",
       "expertGroupId": null
     },
     "0074": {
+      "label": "Business Partner Data GATE API",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-bpdm"
     },
     "0076": {
+      "label": "GoldenRecordEndtoEndRequirementsStandard",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-bpdm"
     },
     "0077": {
+      "label": "Data Quality Dashboard",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": null,
       "expertGroupNote": "BPDM (not covered)"
     },
     "0078": {
+      "label": "Bank Data Verification Dashboard",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": null,
       "expertGroupNote": "BPDM (not covered)"
     },
     "0079": {
+      "label": "NaturalPersonScreeningDashboard",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": null,
       "expertGroupNote": "BPDM (not covered)"
     },
     "0080": {
+      "label": "Fraud Prevention Service",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": null,
       "expertGroupNote": "BPDM (not covered)"
     },
     "0081": {
+      "label": "Country Risk API",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": null,
       "expertGroupNote": "BPDM (not covered)"
     },
     "0084": {
+      "label": "Federated Queries in Data Spaces",
       "committeeId": "cx-com-team-supply-chain-and-quality",
       "expertGroupId": "cx-ex-team-behavioral-twin"
     },
-    "0102": {
-      "committeeId": null,
-      "expertGroupId": null
-    },
     "0105": {
+      "label": "Asset Tracking Use Case",
       "committeeId": "cx-team-sustainability",
       "expertGroupId": "circular-economy"
     },
     "0115": {
+      "label": "Manufacturing Capability Exchange",
       "committeeId": null,
       "expertGroupId": null,
       "expertGroupNote": "MaaS (not covered)"
     },
     "0116": {
+      "label": "Sanction Party Watchlist Dashboard",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": null,
       "expertGroupNote": "BPDM (not covered)"
     },
     "0117": {
+      "label": "Use Case Circular Economy - Secondary Marketplace",
       "committeeId": "cx-team-sustainability",
       "expertGroupId": "circular-economy"
     },
-    "0118": {
-      "committeeId": "cx-com-team-supply-chain-and-quality",
-      "expertGroupId": "cx-ex-team-puris"
-    },
-    "0120": {
-      "committeeId": "cx-com-team-supply-chain-and-quality",
-      "expertGroupId": "cx-ex-team-puris"
-    },
-    "0121": {
-      "committeeId": "cx-com-team-supply-chain-and-quality",
-      "expertGroupId": "cx-ex-team-puris"
-    },
-    "0122": {
-      "committeeId": "cx-com-team-supply-chain-and-quality",
-      "expertGroupId": "cx-ex-team-puris"
-    },
     "0123": {
+      "label": "Quality Use Case Standard",
       "committeeId": "cx-com-team-supply-chain-and-quality",
       "expertGroupId": null
     },
     "0125": {
+      "label": "Traceability Use Case",
       "committeeId": "cx-com-team-supply-chain-and-quality",
       "expertGroupId": "cx-ex-team-traceability"
     },
     "0126": {
+      "label": "Industry Core: Part Type",
       "committeeId": "cx-com-team-industry-core",
       "expertGroupId": null
     },
     "0127": {
+      "label": "Industry Core: Part Instance",
       "committeeId": "cx-com-team-industry-core",
       "expertGroupId": null
     },
     "0128": {
+      "label": "Demand and Capacity Data Exchange",
       "committeeId": "cx-com-team-supply-chain-and-quality",
       "expertGroupId": "cx-ex-team-dcm"
     },
     "0129": {
+      "label": "Request for Quotation Exchange",
       "committeeId": null,
       "expertGroupId": null,
       "expertGroupNote": "MaaS (not covered)"
     },
     "0131": {
+      "label": "Circularity Core",
       "committeeId": "cx-team-sustainability",
       "expertGroupId": "circular-economy"
     },
     "0133": {
+      "label": "Online Control and Simulation",
       "committeeId": "cx-com-team-supply-chain-and-quality",
       "expertGroupId": "cx-ex-team-osim"
     },
     "0135": {
+      "label": "BP company certificate management",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-comp-cert-management"
     },
     "0136": {
+      "label": "Use Case PCF",
       "committeeId": "cx-team-sustainability",
       "expertGroupId": "cx-ex-team-pcf-arch-int"
     },
     "0138": {
+      "label": "Use Case Behaviour Twin Endurance Estimator",
       "committeeId": "cx-com-team-supply-chain-and-quality",
       "expertGroupId": "cx-ex-team-behavioral-twin"
     },
     "0141": {
+      "label": "Use Case Behaviour Twin Health Indicator",
       "committeeId": "cx-com-team-supply-chain-and-quality",
       "expertGroupId": "cx-ex-team-behavioral-twin"
     },
     "0142": {
+      "label": "Shop Floor Information Service",
       "committeeId": null,
       "expertGroupId": null,
       "expertGroupNote": "Modular Production (not covered)"
     },
     "0143": {
+      "label": "Use Case Circular Economy - Digital Product Passport Standard",
       "committeeId": "cx-team-sustainability",
       "expertGroupId": "circular-economy"
     },
     "0144": {
+      "label": "ESS Use Case Standard",
       "committeeId": "cx-team-sustainability",
       "expertGroupId": "human-rights"
     },
-    "0145": {
-      "committeeId": "cx-com-team-supply-chain-and-quality",
-      "expertGroupId": "cx-ex-team-puris"
-    },
     "0146": {
+      "label": "Supply Chain Disruption Notifications",
       "committeeId": "cx-com-team-supply-chain-and-quality",
       "expertGroupId": "cx-ex-team-puris"
     },
     "0149": {
+      "label": "Wallet Requirements",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-ssi"
     },
     "0150": {
+      "label": "Logistics and Customs Use Case",
       "committeeId": "cx-com-team-supply-chain-and-quality",
       "expertGroupId": "logistics"
     },
     "0151": {
+      "label": "Industry Core Basics",
       "committeeId": "cx-com-team-industry-core",
       "expertGroupId": null
     },
     "0152": {
+      "label": "Policy Constraints For Data Exchange",
       "committeeId": "cx-com-team-network-service",
       "expertGroupId": "cx-ex-team-data-sovereignty"
     },
     "0153": {
+      "label": "Tariffs Use Case",
       "committeeId": "cx-com-team-supply-chain-and-quality",
       "expertGroupId": null
     },
     "0154": {
+      "label": "Digital Engineering Master Data",
       "committeeId": "cx-com-team-engineering",
       "expertGroupId": "cx-ex-team-engineering"
     },
     "0155": {
+      "label": "Requirements Engineering",
       "committeeId": "cx-com-team-engineering",
       "expertGroupId": "cx-ex-team-engineering"
+    },
+    "0156": {
+      "label": "Geometry",
+      "committeeId": "cx-com-team-engineering",
+      "expertGroupId": "cx-ex-team-engineering"
+    },
+    "0157": {
+      "label": "Predictive Unit Real-Time Information Service (PURIS)",
+      "committeeId": "cx-com-team-supply-chain-and-quality",
+      "expertGroupId": "cx-ex-team-puris"
+    },
+    "0158": {
+      "label": "Car SBOM",
+      "committeeId": "cx-com-team-supply-chain-and-quality",
+      "expertGroupId": null
+    },
+    "0158-1": {
+      "label": "Car SBOM",
+      "committeeId": "cx-com-team-supply-chain-and-quality",
+      "expertGroupId": null
+    },
+    "0159": {
+      "label": "Material Accounting",
+      "committeeId": "cx-team-sustainability",
+      "expertGroupId": "cx-ex-team-sus-material-accounting"
+    },
+    "0160": {
+      "label": "Battery Passport",
+      "committeeId": "cx-team-sustainability",
+      "expertGroupId": "battery-passport"
+    },
+    "0161": {
+      "label": "ECU Crypto Material",
+      "committeeId": "cx-team-sustainability",
+      "expertGroupId": "cx-ex-team-ecu"
     }
-  }
+  },
+  "rulebooks": [
+    {
+      "label": "PCF Rulebook",
+      "committeeLabel": "Sustainability",
+      "expertGroupLabel": "PCF Methodology and Verification"
+    },
+    {
+      "label": "PCF Verification Framework",
+      "committeeLabel": "Sustainability",
+      "expertGroupLabel": "PCF Methodology and Verification"
+    },
+    {
+      "label": "ESS Code of Conduct",
+      "committeeLabel": "Sustainability",
+      "expertGroupLabel": "ESS Due Diligence"
+    }
+  ]
 }


### PR DESCRIPTION
## Description

This pull request updates the `static/standard-owners.json` file to enhance the metadata for standards, committees, and expert groups. The changes add missing labels, introduce new teams and expert groups, expand the list of standards with descriptive labels, and introduce a new section for rulebooks. These updates improve clarity, traceability, and maintainability of standard ownership information.

**Enhancements to teams and expert groups:**
- Added new expert groups and teams, including `cx-ex-team-sus-material-accounting`, `cx-ex-team-ecu`, and `battery-passport`, each with appropriate labels and URLs. [[1]](diffhunk://#diff-2827ad2d3a9c27c79a0ab00f282650780c1935f985c992022d3809671416afadR85-R92) [[2]](diffhunk://#diff-2827ad2d3a9c27c79a0ab00f282650780c1935f985c992022d3809671416afadR101-R439)

**Improvements to standards metadata:**
- Added descriptive `label` fields to many standards entries, making it easier to identify each standard at a glance.
- Added new standards entries (e.g., `0156` Geometry, `0157` PURIS, `0159` Material Accounting, `0160` Battery Passport, `0161` ECU Crypto Material) with full metadata.
- Removed several obsolete or redundant standards entries (e.g., `0014`, `0015`, `0102`, `0118`, `0120`, `0121`, `0122`, `0145`).

**Introduction of rulebooks:**
- Added a new `rulebooks` section listing key rulebooks, each with a label and associated committee and expert group labels.

**General metadata improvements:**
- Added or updated `expertGroupNote` fields for standards that are not currently covered by an expert group, providing additional context.