### PR TITLE
docs(glossary): add Onboarding Service Provider

### DIFF
--- a/glossary/glossary.json
+++ b/glossary/glossary.json
@@ -8,6 +8,12 @@
       "relatedTerms": ["REST", "GraphQL"]
     },
     {
+      "term": "Onboarding Service Provider",
+      "abbreviation": "OSP",
+      "definition": "[Operating Model](https://catenax-ev.github.io/docs/next/operating-model/who-roles-in-the-catena-x-ecosystem#onboarding-service-provider)",
+      "relatedTerms": ["REST", "GraphQL"]
+    },
+    {
       "term": "REST",
       "abbreviation": "Representational State Transfer",
       "definition": "An architectural style for designing networked applications.",


### PR DESCRIPTION
## Description

*This is a test for an OSP*

This pull request makes a small update to the glossary by adding a new entry for "Onboarding Service Provider" (OSP).

- Added a new glossary entry for "Onboarding Service Provider" (`OSP`) with a definition and related terms.