### PR TITLE
Add Republic of Moldova to clearance List - #25

### DIFF
--- a/docs/regulatory-framework/30000ft/country-clearance-list.md
+++ b/docs/regulatory-framework/30000ft/country-clearance-list.md
@@ -46,6 +46,7 @@ pagination_next: null
 | Philippines | PH |
 | Poland | PL |
 | Portugal | PT |
+| Republic of Moldova | MD |
 | Romania | RO |
 | Serbia | RS |
 | Singapore | SG |

--- a/docs/regulatory-framework/changelog.md
+++ b/docs/regulatory-framework/changelog.md
@@ -6,6 +6,13 @@ sidebar_class_name: separator-top
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.0.3] - 2026-08-10
+
+### Added
+
+- Catena-X: Country Clearance List
+  - add **Republic of Moldova** to "Allow List"
+
 ## [3.0.2] - 2026-04-23
 
 ### Added


### PR DESCRIPTION
## Pull request overview

Updates the regulatory framework documentation to include the Republic of Moldova in the Catena-X Country Clearance “Allow List”, and records the update in the changelog.

**Changes:**
- Added a new 3.0.3 changelog entry documenting the Allow List update.
- Added “Republic of Moldova (MD)” to the Allow List table.