### PR TITLE
Add **Morocco** to "Allow List"

### DIFF
--- a/docs/regulatory-framework/30000ft/country-clearance-list.md
+++ b/docs/regulatory-framework/30000ft/country-clearance-list.md
@@ -40,6 +40,7 @@ pagination_next: null
 | Luxembourg | LU |
 | Malaysia | MY |
 | Malta | MT |
+| Marocco | MA |
 | Mexico | MX |
 | Netherlands | NL |
 | Norway | NOK |

--- a/docs/regulatory-framework/30000ft/country-clearance-list.md
+++ b/docs/regulatory-framework/30000ft/country-clearance-list.md
@@ -40,7 +40,7 @@ pagination_next: null
 | Luxembourg | LU |
 | Malaysia | MY |
 | Malta | MT |
-| Marocco | MA |
+| Morocco | MA |
 | Mexico | MX |
 | Netherlands | NL |
 | Norway | NOK |

--- a/docs/regulatory-framework/changelog.md
+++ b/docs/regulatory-framework/changelog.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Catena-X: Country Clearance List
   - add **Republic of Moldova** to "Conditional List"
+  - add **Marocco** to "Allow List"
 
 ## [3.0.2] - 2026-04-23
 

--- a/docs/regulatory-framework/changelog.md
+++ b/docs/regulatory-framework/changelog.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Catena-X: Country Clearance List
   - add **Republic of Moldova** to "Conditional List"
-  - add **Marocco** to "Allow List"
+  - add **Morocco** to "Allow List"
 
 ## [3.0.2] - 2026-04-23
 


### PR DESCRIPTION
## Pull request overview

This PR updates the Catena-X Country Clearance List documentation by adding Morocco to the Allow List and recording the change in the changelog.

**Changes:**
- Add Morocco (country code MA) to the Allow List table.
- Add a corresponding entry to the 3.0.3 changelog section.

### Reviewed changes

| File | Description |
| ---- | ----------- |
| docs/changelog.md | Adds a changelog bullet noting the new allow-listed country. |
| docs/30000ft/country-clearance-list.md | Adds the country entry to the Allow List table. |